### PR TITLE
Change Java Persistence API Schemas

### DIFF
--- a/code/chapter7/javaee7-jpa-basic/src/main/resources/META-INF/persistence.xml
+++ b/code/chapter7/javaee7-jpa-basic/src/main/resources/META-INF/persistence.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <persistence version="2.1"
-	xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-        http://java.sun.com/xml/ns/persistence
-        http://java.sun.com/xml/ns/persistence/persistence_2_1.xsd">
+        http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
 	<persistence-unit name="primary">
 
 	  <!--  	<jta-data-source>java:/datasources/MySQLDS</jta-data-source>   -->


### PR DESCRIPTION
Starting from version 2.1, JPA schemas share the namespace, http://xmlns.jcp.org/xml/ns/persistence/ instead of the old one of http://java.sun.com/xml/ns/persistence/
